### PR TITLE
Markdown Output

### DIFF
--- a/cli.rb
+++ b/cli.rb
@@ -28,10 +28,10 @@ class MainParser
   options = {}
   #profiles = ['all', 'inv', 'diag', 'perf']
   profiles = ['all'] + Dir.glob('profiles/*').map{ |x| File.basename(x) }
-  formats = ['yaml', 'md']
+  formats = ['yaml', 'md', 'yamdown']
 
   # Defaults
-  options['output'] = 'yaml'
+  options['output'] = 'yamdown'
   options['profile'] = 'all'
   options['file'] = nil
   options['row_height'] = 30

--- a/cli.rb
+++ b/cli.rb
@@ -28,7 +28,7 @@ class MainParser
   options = {}
   #profiles = ['all', 'inv', 'diag', 'perf']
   profiles = ['all'] + Dir.glob('profiles/*').map{ |x| File.basename(x) }
-  formats = ['yaml', 'csv']
+  formats = ['yaml', 'md']
 
   # Defaults
   options['output'] = 'yaml'

--- a/profiles.rb
+++ b/profiles.rb
@@ -116,8 +116,13 @@ class Profiles
         case @output
         when 'md'
           File.write(@file, self._to_md(@results))
-        else
+        when 'yaml'
           File.write(@file, @results.to_yaml)
+        when 'yamdown'
+          File.write(@file, self._to_yamdown(@results))
+        else
+          puts "Output format #{@output} is unknown to benchware, using yamdown"
+          File.write(@file, self._to_yamdown(@results))
         end
       end
     end
@@ -161,6 +166,34 @@ class Profiles
         end
       end
       self._continue
+    end
+  end
+
+  def _to_yamdown(data)
+    data.each do |node, node_data|
+      puts "#{node}:"
+      puts "  name: #{node}"
+      puts "  type: NOT-YET-IMPLEMENTED"
+      puts "  primary_group: NOT-YET-IMPLEMENTED"
+      puts "  secondary_group: NOT-YET-IMPLEMENTED"
+      puts "  info: |"
+      node_data.each do |module_name, module_commands|
+        puts "## #{self._md_tidy(module_name)}"
+        puts ""
+        puts "| | |"
+        puts "| --- | --- |"
+        module_commands.each do |command, output|
+          if output.class == Hash
+            puts "| __#{self._md_tidy(command)}__ |  |"
+            output.each do |entry, out|
+              puts "| #{self._md_tidy(entry)} | #{self._md_tidy(out)} |"
+            end
+          else
+            puts "| __#{self._md_tidy(command)}__ | #{self._md_tidy(output)} |"
+          end
+        end
+        puts ""
+      end
     end
   end
 

--- a/profiles.rb
+++ b/profiles.rb
@@ -113,7 +113,12 @@ class Profiles
       end
 
       if @file
-        File.write(@file, @results.to_yaml)
+        case @output
+        when 'md'
+          File.write(@file, self._to_md(@results))
+        else
+          File.write(@file, @results.to_yaml)
+        end
       end
     end
   end
@@ -159,18 +164,53 @@ class Profiles
     end
   end
 
+  def _to_md(data)
+    count = 1
+    puts "# Table of Contents"
+    data.each do |node, node_data|
+      puts "#{count}. [#{self._md_tidy(node)}](##{self._md_tidy(node)})"
+      count += 1
+    end
+    puts ""
+    data.each do |node, node_data|
+      puts "# #{self._md_tidy(node)}"
+      node_data.each do |module_name, module_commands|
+        puts "## #{self._md_tidy(module_name)}"
+        puts "| | |"
+        puts "| --- | --- |"
+        module_commands.each do |command, output|
+          if output.class == Hash
+            puts "| __#{self._md_tidy(command)}__ |  |"
+            output.each do |entry, out|
+              puts "| #{self._md_tidy(entry)} | #{self._md_tidy(out)} |"
+            end
+          else
+            puts "| __#{self._md_tidy(command)}__ | #{self._md_tidy(output)} |"
+          end
+        end
+      end
+    end
+  end
+
+  def _md_tidy(string)
+    string = string.to_s
+    unless string.empty?
+      # Replace underscores with spaces
+      string_clean = string.sub('_', ' ')
+
+      # Capitalise words 
+      string_clean = string_clean.split.map(&:capitalize).join(' ')
+
+      # Return it
+      return string_clean
+    else
+      return string
+    end
+  end
+
   def results()
     unless @quiet
-      if @format == 'csv'
-        # TODO: actually write the csv output format
-        puts "nodename,module_name,"
-        @results.each do |node, module_name|
-          puts "node,#{module_name},"
-        end
-      else
-        #puts @results.to_yaml
-        self._page_output(@results)
-      end
+      self._page_output(@results)
     end
   end
 

--- a/profiles.rb
+++ b/profiles.rb
@@ -65,7 +65,7 @@ class Profiles
   end
 
   def _run_script(node, script, entry=nil)
-    out = `ssh #{node} "bash -s" -- < #{script} #{entry}`
+    out = `ssh #{node} "bash -l -s" -- < #{script} #{entry}`
     return out
   end
 

--- a/profiles/perf/memtester.sh
+++ b/profiles/perf/memtester.sh
@@ -10,7 +10,7 @@ ulimit -l unlimited
 
 if hash memtester 2> /dev/null ; then
     MEMTESTER=$(which memtester)
-elif module load apps/memtester 2> /dev/null ; then
+elif module load 'apps/memtester' 2> /dev/null ; then
     MEMTESTER=$(which memtester)
 else
     echo "memtester cannot be found"


### PR DESCRIPTION
This PR allows for the output file to be in markdown instead of YAML. It separates nodes into header-separated sections and adds a table of contents.

Example:
<img width="1273" alt="screen shot 2018-07-30 at 14 28 50" src="https://user-images.githubusercontent.com/27725639/43400206-02905648-9405-11e8-9ee9-b02af054a6b7.png">

Still required:
- Testing the code on a cluster to ensure both yaml and md output works as expected
- Inputting data on FlightCenter to ensure the markdown displays as expected