### PR TITLE
Allow for package dependencies and add debugging log

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,29 +4,30 @@ A utility for checking, testing and benchmarking a cluster.
 
 ## Running Commands 
 
-### Run all tests for group
+### Run all tests for a genders group
 
 ```
-benchware --all --group=nodes
-benchware -a -g nodes
+cd /opt/benchware && ./benchware.rb --all --nodes "$(nodeattr -s mygendersgroup)"
+cd /opt/benchware && ./benchware.rb -a -n "$(nodeattr -s mygendersgroup)"
 ```
 
-### Run all tests for node
+### Run inventory checks for some nodes
 
 ```
-benchware --all --node=node001
-benchware -a -n node001
+cd /opt/benchware && ./benchware.rb --profile inv --nodes "node001 node002 thisnode01"
+cd /opt/benchware && ./benchware.rb -p inv -n "node001 node002 thisnode01"
 ```
-
-###
 
 ### Output formats
 
-Data will be output in YAML by default but can also be set as CSV
+The output format refers to how the file written by benchware will format the data. Without the `-q` option benchware will do a page-based yaml output which can be scrolled through.
+
+Data will be output in yamdown by default, a hybrid of yaml and markdown for use with Flight Center web services. Data can also be output in plain yaml.
 
 ## List of Checks and Tests
 
 - CPU
+  - Number of CPUs
   - Number of Cores
   - Hyperthreading (enable/disable)
   - Model #
@@ -72,6 +73,7 @@ Data will be output in YAML by default but can also be set as CSV
 
 ```
 module_name: name_of_module
+dependencies: "package_name another_package"
 repeat_list: "command to return newline separated list of items to run the commands on"
 commands:
   command_name: "way of running test"
@@ -79,5 +81,6 @@ scripts:
   script_name: "path/to/script"
 ```
 
+- The list of packages in `dependencies` will be installed with yum prior to any of the commands or scripts within it running
 - To use the entries in the `repeat_list` variable (`repeat_list` is optional) put all caps `ENTRY` in the command for it to be substituted at execution. For scripts ENTRY will be the first argument given to the script upon execution.
 - Scripts allow for larger commands (which require a bit more than a one-liner to get suitable output) to be specified with a relative path to the _benchware installation directory_, this script is then copied across to the client node temporarily to be executed.

--- a/cli.rb
+++ b/cli.rb
@@ -36,6 +36,7 @@ class MainParser
   options['file'] = "/tmp/benchware.out.#{('a'..'z').to_a.shuffle[0,8].join}"
   options['row_height'] = 30
   options['quiet'] = false
+  options['verbose'] = false
 
   opt_parser = OptionParser.new do |opt|
     opt.banner = "Usage: benchware [OPTIONS] -n \"NODES\""
@@ -69,6 +70,10 @@ class MainParser
 
     opt.on("-q","--quiet","don't display results in terminal, useful for just writing to a file") do |quiet|
       options['quiet'] = quiet
+    end
+
+    opt.on("-v","--verbose","create additional debug info in /var/log/benchware.log") do |verbose|
+      options['verbose'] = verbose
     end
 
     opt.on("-h","--help","show this help screen") do

--- a/profiles.rb
+++ b/profiles.rb
@@ -34,6 +34,8 @@ class Profiles
     @file = options['file']
     @row_height = options['row_height']
     @quiet = options['quiet']
+    @verbose = options['verbose']
+    @verbose_log = '/var/log/benchware.log'
     @jobs = {}
     @results = {}
     @meta = YAML.load_file("profiles/meta.yaml")
@@ -52,6 +54,13 @@ class Profiles
     module_files.each do |infile|
       yaml_load = YAML.load_file(infile)
       @jobs[yaml_load['module_name']] = yaml_load.dup.tap { |h| h.delete('module_name') }
+    end
+
+    if @verbose
+      # Write to global log
+      File.open(file, 'a') { |f| f.write("#{Time.now} - Running Benchware with the following options - "\
+                                        "profile = #{@profile}, nodes = #{@nodes}, output = #{@output}, file = #{@file}"\
+                                        "quiet = #{@quiet}, jobs = #{@jobs}")}
     end
   end
 
@@ -90,6 +99,17 @@ class Profiles
 
       # Run the rest of the jobs
       @jobs.each do |module_name, details|
+
+        # Install dependencies
+        if details.key?('dependencies')
+          # Captures all dependency install output and prepends the nodename
+          out = self._run_cmd(node, "yum install -y #{dependencies}").split("\n").map {|l| "#{node}: #{l}" }.join("\n")
+          if @verbose
+            # Write to global log
+            File.open(file, 'a') { |f| f.write(out)}
+          end
+        end
+
         @results[node][module_name] = {}
         if details['repeat_list']
           run_list = self._run_cmd(node, details['repeat_list']).split(/\n/)

--- a/profiles/inv/02-cpu.yaml
+++ b/profiles/inv/02-cpu.yaml
@@ -2,4 +2,5 @@ module_name: cpu
 commands:
   model: "grep -m 1 name /proc/cpuinfo |awk -F '\t' '{print $2}' |sed 's/: //g'"
   num_cores: "grep -c processor /proc/cpuinfo"
+  count: "lscpu |grep '^CPU(s):' |awk '{print $2}'"
   hyperthreading: "[[ $(grep -m 1 'cpu cores' /proc/cpuinfo |awk '{print $4}') != $(grep -m 1 'siblings' /proc/cpuinfo |awk '{print $3}') ]] && echo 'enabled' || echo 'disabled'"

--- a/profiles/inv/07-gpu.yaml
+++ b/profiles/inv/07-gpu.yaml
@@ -1,4 +1,5 @@
 module_name: gpu
+dependencies: pciutils
 repeat_list: "lspci |grep -i nvid |awk '{print $1}'"
 commands:
   type: "lspci |grep ^ENTRY |sed 's/.*: //g;s/ (.*//g'"

--- a/templates/flightcenter.md.erb
+++ b/templates/flightcenter.md.erb
@@ -12,7 +12,7 @@
 
     - Model: <%= node_data['cpu']['model'] %>
     - Cores: <%= node_data['cpu']['num_cores'] %>
-    - Count: NOT IMPLEMENTED
+    - Count: <%= node_data['cpu']['count'] %>
     - Hyperthreading: <%= node_data['cpu']['hyperthreading'] %>
 
     ## RAM


### PR DESCRIPTION
Systems don't usually have `pciutils` installed so this PR addresses that issue by adding general dependency support. 

In the event that something is going weird with installs the output from the yum command can be captured and put into `/var/log/benchware`. This is very rudimentary debug logging but should do the job.