### PR TITLE
Support old ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
 source 'https://rubygems.org'
-unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
-  gem 'cli-ui'
-end
+gem 'cli-ui', '1.1.1'
 gem 'erubis'

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
+unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
   gem 'cli-ui'
 end
 gem 'erubis'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
-gem 'cli-ui'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
+  gem 'cli-ui'
+end
 gem 'erubis'

--- a/README.md
+++ b/README.md
@@ -4,29 +4,30 @@ A utility for checking, testing and benchmarking a cluster.
 
 ## Running Commands 
 
-### Run all tests for group
+### Run all tests for a genders group
 
 ```
-benchware --all --group=nodes
-benchware -a -g nodes
+cd /opt/benchware && ./benchware.rb --all --nodes "$(nodeattr -s mygendersgroup)"
+cd /opt/benchware && ./benchware.rb -a -n "$(nodeattr -s mygendersgroup)"
 ```
 
-### Run all tests for node
+### Run inventory checks for some nodes
 
 ```
-benchware --all --node=node001
-benchware -a -n node001
+cd /opt/benchware && ./benchware.rb --profile inv --nodes "node001 node002 thisnode01"
+cd /opt/benchware && ./benchware.rb -p inv -n "node001 node002 thisnode01"
 ```
-
-###
 
 ### Output formats
 
-Data will be output in YAML by default but can also be set as CSV
+The output format refers to how the file written by benchware will format the data. Without the `-q` option benchware will do a page-based yaml output which can be scrolled through.
+
+Data will be output in yamdown by default, a hybrid of yaml and markdown for use with Flight Center web services. Data can also be output in plain yaml.
 
 ## List of Checks and Tests
 
 - CPU
+  - Number of CPUs
   - Number of Cores
   - Hyperthreading (enable/disable)
   - Model #
@@ -72,6 +73,7 @@ Data will be output in YAML by default but can also be set as CSV
 
 ```
 module_name: name_of_module
+dependencies: "package_name another_package"
 repeat_list: "command to return newline separated list of items to run the commands on"
 commands:
   command_name: "way of running test"
@@ -79,5 +81,6 @@ scripts:
   script_name: "path/to/script"
 ```
 
+- The list of packages in `dependencies` will be installed with yum prior to any of the commands or scripts within it running
 - To use the entries in the `repeat_list` variable (`repeat_list` is optional) put all caps `ENTRY` in the command for it to be substituted at execution. For scripts ENTRY will be the first argument given to the script upon execution.
 - Scripts allow for larger commands (which require a bit more than a one-liner to get suitable output) to be specified with a relative path to the _benchware installation directory_, this script is then copied across to the client node temporarily to be executed.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 A utility for checking, testing and benchmarking a cluster.
 
+## Installing
+
+- Clone benchware
+
+```
+git clone https://github.com/alces-software/benchware /opt/benchware
+```
+
+- Install gem dependencies
+
+```
+gem install cli-ui
+gem install erubis
+```
+
 ## Running Commands 
 
 ### Run all tests for a genders group

--- a/benchware.rb
+++ b/benchware.rb
@@ -35,6 +35,7 @@ run_profile = Profiles.new(options)
 run_profile.run_jobs()
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
   puts "Ruby version too low for page output, only writing to file"
+  puts "More info - https://github.com/alces-software/benchware/pull/7"
 else
   run_profile.results()
 end

--- a/benchware.rb
+++ b/benchware.rb
@@ -33,4 +33,8 @@ options = MainParser.parse(ARGV)
 # Run Command
 run_profile = Profiles.new(options)
 run_profile.run_jobs()
-run_profile.results()
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
+  puts "Ruby version too low for page output, only writing to file"
+else
+  run_profile.results()
+end

--- a/benchware.rb
+++ b/benchware.rb
@@ -33,9 +33,4 @@ options = MainParser.parse(ARGV)
 # Run Command
 run_profile = Profiles.new(options)
 run_profile.run_jobs()
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
-  puts "Ruby version too low for page output, only writing to file"
-  puts "More info - https://github.com/alces-software/benchware/pull/7"
-else
-  run_profile.results()
-end
+run_profile.results()

--- a/cli.rb
+++ b/cli.rb
@@ -36,6 +36,7 @@ class MainParser
   options['file'] = "/tmp/benchware.out.#{('a'..'z').to_a.shuffle[0,8].join}"
   options['row_height'] = 30
   options['quiet'] = false
+  options['verbose'] = false
 
   opt_parser = OptionParser.new do |opt|
     opt.banner = "Usage: benchware [OPTIONS] -n \"NODES\""
@@ -69,6 +70,10 @@ class MainParser
 
     opt.on("-q","--quiet","don't display results in terminal, useful for just writing to a file") do |quiet|
       options['quiet'] = quiet
+    end
+
+    opt.on("-v","--verbose","create additional debug info in /var/log/benchware.log") do |verbose|
+      options['verbose'] = verbose
     end
 
     opt.on("-h","--help","show this help screen") do

--- a/profiles.rb
+++ b/profiles.rb
@@ -21,7 +21,7 @@
 #==============================================================================
 
 require 'yaml'
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
+unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
   require 'cli/ui'
 end
 require 'io/console'

--- a/profiles.rb
+++ b/profiles.rb
@@ -21,9 +21,7 @@
 #==============================================================================
 
 require 'yaml'
-unless Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
-  require 'cli/ui'
-end
+require 'cli/ui'
 require 'io/console'
 require 'erubis'
 

--- a/profiles.rb
+++ b/profiles.rb
@@ -21,7 +21,9 @@
 #==============================================================================
 
 require 'yaml'
-require 'cli/ui'
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.1')
+  require 'cli/ui'
+end
 require 'io/console'
 require 'erubis'
 
@@ -161,6 +163,7 @@ class Profiles
         end
       end
     end
+    puts "Results written to #{@file}"
   end
 
   def _continue
@@ -223,7 +226,6 @@ class Profiles
     unless @quiet
       self._page_output(@results)
     end
-    puts "Results written to #{@file}"
   end
 
 end

--- a/profiles.rb
+++ b/profiles.rb
@@ -34,6 +34,8 @@ class Profiles
     @file = options['file']
     @row_height = options['row_height']
     @quiet = options['quiet']
+    @verbose = options['verbose']
+    @verbose_log = '/var/log/benchware.log'
     @jobs = {}
     @results = {}
     @meta = YAML.load_file("profiles/meta.yaml")
@@ -52,6 +54,13 @@ class Profiles
     module_files.each do |infile|
       yaml_load = YAML.load_file(infile)
       @jobs[yaml_load['module_name']] = yaml_load.dup.tap { |h| h.delete('module_name') }
+    end
+
+    if @verbose
+      # Write to global log
+      File.open(file, 'a') { |f| f.write("#{Time.now} - Running Benchware with the following options - "\
+                                        "profile = #{@profile}, nodes = #{@nodes}, output = #{@output}, file = #{@file}"\
+                                        "quiet = #{@quiet}, jobs = #{@jobs}")}
     end
   end
 
@@ -90,6 +99,17 @@ class Profiles
 
       # Run the rest of the jobs
       @jobs.each do |module_name, details|
+
+        # Install dependencies
+        if details.key?('dependencies')
+          # Captures all dependency install output and prepends the nodename
+          out = self._run_cmd(node, "yum install -y #{dependencies}").split("\n").map {|l| "#{node}: #{l}" }.join("\n")
+          if @verbose
+            # Write to global log
+            File.open(file, 'a') { |f| f.write(out)}
+          end
+        end
+
         @results[node][module_name] = {}
         if details['repeat_list']
           run_list = self._run_cmd(node, details['repeat_list']).split(/\n/)

--- a/profiles/inv/02-cpu.yaml
+++ b/profiles/inv/02-cpu.yaml
@@ -2,4 +2,5 @@ module_name: cpu
 commands:
   model: "grep -m 1 name /proc/cpuinfo |awk -F '\t' '{print $2}' |sed 's/: //g'"
   num_cores: "grep -c processor /proc/cpuinfo"
+  count: "lscpu |grep '^CPU(s):' |awk '{print $2}'"
   hyperthreading: "[[ $(grep -m 1 'cpu cores' /proc/cpuinfo |awk '{print $4}') != $(grep -m 1 'siblings' /proc/cpuinfo |awk '{print $3}') ]] && echo 'enabled' || echo 'disabled'"

--- a/profiles/inv/07-gpu.yaml
+++ b/profiles/inv/07-gpu.yaml
@@ -1,4 +1,5 @@
 module_name: gpu
+dependencies: pciutils
 repeat_list: "lspci |grep -i nvid |awk '{print $1}'"
 commands:
   type: "lspci |grep ^ENTRY |sed 's/.*: //g;s/ (.*//g'"

--- a/templates/flightcenter.md.erb
+++ b/templates/flightcenter.md.erb
@@ -12,7 +12,7 @@
 
     - Model: <%= node_data['cpu']['model'] %>
     - Cores: <%= node_data['cpu']['num_cores'] %>
-    - Count: NOT IMPLEMENTED
+    - Count: <%= node_data['cpu']['count'] %>
     - Hyperthreading: <%= node_data['cpu']['hyperthreading'] %>
 
     ## RAM


### PR DESCRIPTION
Based on #6 

This commit removes the need to install `rvm` on CentOS 7 in order to run benchware. It seems there is some issue (that I haven't bothered fully debugging) in cli-ui when used with the ruby version on CentOS. As this is only used for doing the page output and seeing as that isn't the common use-case for benchware it is simply ignored if on an older version.

The error with `cli-ui` is as follows
```
[root@controller [mycluster] benchware]# ./benchware.rb --help
/usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require': /usr/local/share/gems/gems/cli-ui-1.1.4/lib/cli/ui/stdout_router.rb:149: syntax error, unexpected ')' (SyntaxError)
/usr/local/share/gems/gems/cli-ui-1.1.4/lib/cli/ui/stdout_router.rb:151: syntax error, unexpected <<
            raise ArgumentError, <<~EOF
                                   ^
/usr/local/share/gems/gems/cli-ui-1.1.4/lib/cli/ui/stdout_router.rb:165: syntax error, unexpected keyword_ensure, expecting keyword_end
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/local/share/gems/gems/cli-ui-1.1.4/lib/cli/ui.rb:163:in `<top (required)>'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:135:in `require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:144:in `require'
	from /opt/benchware/profiles.rb:24:in `<top (required)>'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /usr/share/rubygems/rubygems/core_ext/kernel_require.rb:55:in `require'
	from ./benchware.rb:28:in `<main>'
```